### PR TITLE
Android automatic refactor - Recycle

### DIFF
--- a/app/src/androidTest/java/org/gateshipone/odyssey/NowPlayingInformationTest.java
+++ b/app/src/androidTest/java/org/gateshipone/odyssey/NowPlayingInformationTest.java
@@ -86,6 +86,9 @@ public class NowPlayingInformationTest {
 
         // Read the data.
         NowPlayingInformation createdFromParcel = NowPlayingInformation.CREATOR.createFromParcel(parcel);
+		if (parcel != null) {
+			parcel.recycle();
+		}
 
         // Verify that the received data is correct.
         assertThat(createdFromParcel.getPlayState(), is(TEST_PLAYING));

--- a/app/src/androidTest/java/org/gateshipone/odyssey/TrackModelTest.java
+++ b/app/src/androidTest/java/org/gateshipone/odyssey/TrackModelTest.java
@@ -76,6 +76,9 @@ public class TrackModelTest {
 
         // Read the data.
         TrackModel createdFromParcel = TrackModel.CREATOR.createFromParcel(parcel);
+		if (parcel != null) {
+			parcel.recycle();
+		}
 
         // Verify that the received data is correct.
         assertThat(createdFromParcel.getTrackName(), is(TEST_TRACKNAME));


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "Recycle".

Some resources (e.g., ```Cursor``` instances) should be closed when they are no longer necessary. 

I have made a previous validation of the changes and they seem correct.
Please consider them and let me know if you agree with them.

Best,
Luis
