### PR TITLE
Ensure non empty track titles, failback to filename

### DIFF
--- a/app/src/main/java/org/gateshipone/odyssey/models/TrackModel.java
+++ b/app/src/main/java/org/gateshipone/odyssey/models/TrackModel.java
@@ -167,7 +167,7 @@ public class TrackModel implements GenericModel, Parcelable {
     /**
      * Return the name of the track, or the file basename if empty
      */
-    public String getTrackTitle() {
+    public String getTrackDisplayedName() {
         if (mTrackName.isEmpty()) {
             return mTrackURL.substring(mTrackURL.lastIndexOf('/') + 1, mTrackURL.length());
         }

--- a/app/src/main/java/org/gateshipone/odyssey/models/TrackModel.java
+++ b/app/src/main/java/org/gateshipone/odyssey/models/TrackModel.java
@@ -165,6 +165,17 @@ public class TrackModel implements GenericModel, Parcelable {
     }
 
     /**
+     * Return the name of the track, or the file basename if empty
+     */
+    public String getTrackTitle() {
+        if (mTrackName.isEmpty()) {
+            return mTrackURL.substring(mTrackURL.lastIndexOf('/') + 1, mTrackURL.length());
+        }
+
+        return mTrackName;
+    }
+
+    /**
      * Return the name of the artist
      */
     public String getTrackArtistName() {

--- a/app/src/main/java/org/gateshipone/odyssey/playbackservice/managers/OdysseyNotificationManager.java
+++ b/app/src/main/java/org/gateshipone/odyssey/playbackservice/managers/OdysseyNotificationManager.java
@@ -143,7 +143,7 @@ public class OdysseyNotificationManager {
             notificationStyle.setShowActionsInCompactView(1, 2);
             notificationStyle.setMediaSession(mediaSessionToken);
             mNotificationBuilder.setStyle(notificationStyle);
-            mNotificationBuilder.setContentTitle(track.getTrackName());
+            mNotificationBuilder.setContentTitle(track.getTrackTitle());
             mNotificationBuilder.setContentText(track.getTrackArtistName());
 
             // Remove unnecessary time info

--- a/app/src/main/java/org/gateshipone/odyssey/playbackservice/managers/OdysseyNotificationManager.java
+++ b/app/src/main/java/org/gateshipone/odyssey/playbackservice/managers/OdysseyNotificationManager.java
@@ -143,7 +143,7 @@ public class OdysseyNotificationManager {
             notificationStyle.setShowActionsInCompactView(1, 2);
             notificationStyle.setMediaSession(mediaSessionToken);
             mNotificationBuilder.setStyle(notificationStyle);
-            mNotificationBuilder.setContentTitle(track.getTrackTitle());
+            mNotificationBuilder.setContentTitle(track.getTrackDisplayedName());
             mNotificationBuilder.setContentText(track.getTrackArtistName());
 
             // Remove unnecessary time info

--- a/app/src/main/java/org/gateshipone/odyssey/playbackservice/managers/PlaybackServiceStatusHelper.java
+++ b/app/src/main/java/org/gateshipone/odyssey/playbackservice/managers/PlaybackServiceStatusHelper.java
@@ -215,7 +215,7 @@ public class PlaybackServiceStatusHelper {
             metaDataBuilder.putString(MediaMetadataCompat.METADATA_KEY_ALBUM, track.getTrackAlbumName());
             metaDataBuilder.putString(MediaMetadataCompat.METADATA_KEY_ARTIST, track.getTrackArtistName());
             metaDataBuilder.putString(MediaMetadataCompat.METADATA_KEY_ALBUM_ARTIST, track.getTrackArtistName());
-            metaDataBuilder.putString(MediaMetadataCompat.METADATA_KEY_DISPLAY_TITLE, track.getTrackTitle());
+            metaDataBuilder.putString(MediaMetadataCompat.METADATA_KEY_DISPLAY_TITLE, track.getTrackDisplayedName());
             metaDataBuilder.putLong(MediaMetadataCompat.METADATA_KEY_TRACK_NUMBER, track.getTrackNumber());
             metaDataBuilder.putLong(MediaMetadataCompat.METADATA_KEY_DURATION, track.getTrackDuration());
 

--- a/app/src/main/java/org/gateshipone/odyssey/playbackservice/managers/PlaybackServiceStatusHelper.java
+++ b/app/src/main/java/org/gateshipone/odyssey/playbackservice/managers/PlaybackServiceStatusHelper.java
@@ -215,7 +215,7 @@ public class PlaybackServiceStatusHelper {
             metaDataBuilder.putString(MediaMetadataCompat.METADATA_KEY_ALBUM, track.getTrackAlbumName());
             metaDataBuilder.putString(MediaMetadataCompat.METADATA_KEY_ARTIST, track.getTrackArtistName());
             metaDataBuilder.putString(MediaMetadataCompat.METADATA_KEY_ALBUM_ARTIST, track.getTrackArtistName());
-            metaDataBuilder.putString(MediaMetadataCompat.METADATA_KEY_DISPLAY_TITLE, track.getTrackName());
+            metaDataBuilder.putString(MediaMetadataCompat.METADATA_KEY_DISPLAY_TITLE, track.getTrackTitle());
             metaDataBuilder.putLong(MediaMetadataCompat.METADATA_KEY_TRACK_NUMBER, track.getTrackNumber());
             metaDataBuilder.putLong(MediaMetadataCompat.METADATA_KEY_DURATION, track.getTrackDuration());
 

--- a/app/src/main/java/org/gateshipone/odyssey/viewitems/ListViewItem.java
+++ b/app/src/main/java/org/gateshipone/odyssey/viewitems/ListViewItem.java
@@ -220,7 +220,6 @@ public class ListViewItem extends GenericImageViewItem {
         // title (number + name)
         String trackTitle = "";
         int trackNumber = track.getTrackNumber();
-        String trackName = track.getTrackName();
         String formattedTrackNumber = FormatHelper.formatTrackNumber(trackNumber);
         String albumName = track.getTrackAlbumName();
         String artistName = track.getTrackArtistName();
@@ -237,9 +236,7 @@ public class ListViewItem extends GenericImageViewItem {
             trackTitle += formattedTrackNumber + " - ";
         }
 
-        if (!trackName.isEmpty()) {
-            trackTitle += trackName;
-        }
+        trackTitle += track.getTrackDisplayedName();
 
         // subtitle (artist + album)
         String trackSubtitle = artistName;
@@ -252,10 +249,6 @@ public class ListViewItem extends GenericImageViewItem {
 
         // duration
         String trackDuration = FormatHelper.formatTracktimeFromMS(context, track.getTrackDuration());
-
-        if (trackTitle.isEmpty()) {
-            trackTitle = track.getTrackTitle();
-        }
 
         setTitle(trackTitle);
         setSubtitle(trackSubtitle);

--- a/app/src/main/java/org/gateshipone/odyssey/viewitems/ListViewItem.java
+++ b/app/src/main/java/org/gateshipone/odyssey/viewitems/ListViewItem.java
@@ -253,6 +253,10 @@ public class ListViewItem extends GenericImageViewItem {
         // duration
         String trackDuration = FormatHelper.formatTracktimeFromMS(context, track.getTrackDuration());
 
+        if (trackTitle.isEmpty()) {
+            trackTitle = track.getTrackTitle();
+        }
+
         setTitle(trackTitle);
         setSubtitle(trackSubtitle);
         setAddtionalSubtitle(trackDuration);

--- a/app/src/main/java/org/gateshipone/odyssey/views/NowPlayingView.java
+++ b/app/src/main/java/org/gateshipone/odyssey/views/NowPlayingView.java
@@ -1112,7 +1112,7 @@ public class NowPlayingView extends RelativeLayout implements SeekBar.OnSeekBarC
         TrackModel currentTrack = info.getCurrentTrack();
 
         // set tracktitle, album, artist and albumcover
-        mTrackTitle.setText(currentTrack.getTrackTitle());
+        mTrackTitle.setText(currentTrack.getTrackDisplayedName());
 
 
         // Check if the album title changed. If true, start the cover generator thread.

--- a/app/src/main/java/org/gateshipone/odyssey/views/NowPlayingView.java
+++ b/app/src/main/java/org/gateshipone/odyssey/views/NowPlayingView.java
@@ -1112,7 +1112,7 @@ public class NowPlayingView extends RelativeLayout implements SeekBar.OnSeekBarC
         TrackModel currentTrack = info.getCurrentTrack();
 
         // set tracktitle, album, artist and albumcover
-        mTrackTitle.setText(currentTrack.getTrackName());
+        mTrackTitle.setText(currentTrack.getTrackTitle());
 
 
         // Check if the album title changed. If true, start the cover generator thread.

--- a/app/src/main/java/org/gateshipone/odyssey/widget/OdysseyWidgetProvider.java
+++ b/app/src/main/java/org/gateshipone/odyssey/widget/OdysseyWidgetProvider.java
@@ -145,7 +145,7 @@ OdysseyWidgetProvider extends AppWidgetProvider {
         if (info != null) {
             TrackModel item = info.getCurrentTrack();
             if (item != null) {
-                mViews.setTextViewText(R.id.widget_big_trackName, item.getTrackName());
+                mViews.setTextViewText(R.id.widget_big_trackName, item.getTrackTitle());
                 mViews.setTextViewText(R.id.widget_big_ArtistAlbum, item.getTrackArtistName());
 
                 // Check if the tracks album changed

--- a/app/src/main/java/org/gateshipone/odyssey/widget/OdysseyWidgetProvider.java
+++ b/app/src/main/java/org/gateshipone/odyssey/widget/OdysseyWidgetProvider.java
@@ -145,7 +145,7 @@ OdysseyWidgetProvider extends AppWidgetProvider {
         if (info != null) {
             TrackModel item = info.getCurrentTrack();
             if (item != null) {
-                mViews.setTextViewText(R.id.widget_big_trackName, item.getTrackTitle());
+                mViews.setTextViewText(R.id.widget_big_trackName, item.getTrackDisplayedName());
                 mViews.setTextViewText(R.id.widget_big_ArtistAlbum, item.getTrackArtistName());
 
                 // Check if the tracks album changed


### PR DESCRIPTION
Hello,

I just discovered Odyssey and this seems like a Music Player that does what I expect from a Music Player on a phone. Thank you for this nice piece of software!

I have untagged files, and they currently appear blank in the playlist, in the notifications and on the Now Playing screen, which makes Odyssey almost useless for me.

This commit fixes this by failing back to the filename when nothing else is available. I was not sure whether the file extension should be hidden. I decided to keep it, since this gives a hint to the user that their files are not properly tagged and it makes it clear that what is shown is from the name of the file. It also gives more information at no cost (displaying it is not misleading and does not clutter the UI) and requires less code.