### PR TITLE
Fix remembering scrolling position

### DIFF
--- a/app/src/main/java/org/gateshipone/odyssey/fragments/MyMusicFragment.java
+++ b/app/src/main/java/org/gateshipone/odyssey/fragments/MyMusicFragment.java
@@ -121,7 +121,13 @@ public class MyMusicFragment extends Fragment implements TabLayout.OnTabSelected
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.fragment_my_music, container, false);
+        View view =  inflater.inflate(R.layout.fragment_my_music, container, false);
+
+        // inflating this here is not a good idea AFAIK
+        mMyMusicViewPager = view.findViewById(R.id.my_music_viewpager);
+        mMyMusicViewPager.setOffscreenPageLimit(2);
+
+        return view;
     }
 
     @Override
@@ -135,7 +141,6 @@ public class MyMusicFragment extends Fragment implements TabLayout.OnTabSelected
         mMyMusicViewPager = view.findViewById(R.id.my_music_viewpager);
         mMyMusicPagerAdapter = new MyMusicPagerAdapter(getChildFragmentManager());
         mMyMusicViewPager.setAdapter(mMyMusicPagerAdapter);
-        mMyMusicViewPager.setOffscreenPageLimit(2);
         tabLayout.setupWithViewPager(mMyMusicViewPager, false);
         tabLayout.addOnTabSelectedListener(this);
 


### PR DESCRIPTION
Relates to #232 

Since 005835269af99eae73b0a13cacce386334c20ee0 the tabs _albums_ and _artists_ do not remember the user's position anymore. The culprit seems to be a call not happening early on in `onCreateView()` but rather with initialization in `onViewCreated()`. 

Reverting this does not seem like an ideal solution. Suggestions are welcome in case anybody knows how to handle this properly.