### PR TITLE
Restore links to Odyssey project and rename M.A.L.P. variables.

### DIFF
--- a/app/src/main/res/anim/fragment_fade_in.xml
+++ b/app/src/main/res/anim/fragment_fade_in.xml
@@ -4,7 +4,7 @@
   ~  (Hendrik Borghorst & Frederik Luetkes)
   ~
   ~  The AUTHORS.md file contains a detailed contributors list:
-  ~  <https://gitlab.com/gateship-one/malp/blob/master/AUTHORS.md>
+  ~  <https://github.com/gateship-one/odyssey/blob/master/AUTHORS.md>
   ~
   ~  This program is free software: you can redistribute it and/or modify
   ~  it under the terms of the GNU General Public License as published by
@@ -25,5 +25,4 @@
     android:interpolator="@android:anim/decelerate_interpolator"
     android:fromAlpha="0"
     android:toAlpha="1" />
-
 

--- a/app/src/main/res/anim/fragment_fade_out.xml
+++ b/app/src/main/res/anim/fragment_fade_out.xml
@@ -4,7 +4,7 @@
   ~  (Hendrik Borghorst & Frederik Luetkes)
   ~
   ~  The AUTHORS.md file contains a detailed contributors list:
-  ~  <https://gitlab.com/gateship-one/malp/blob/master/AUTHORS.md>
+  ~  <https://github.com/gateship-one/odyssey/blob/master/AUTHORS.md>
   ~
   ~  This program is free software: you can redistribute it and/or modify
   ~  it under the terms of the GNU General Public License as published by

--- a/app/src/main/res/anim/fragment_slide_in.xml
+++ b/app/src/main/res/anim/fragment_slide_in.xml
@@ -4,7 +4,7 @@
   ~  (Hendrik Borghorst & Frederik Luetkes)
   ~
   ~  The AUTHORS.md file contains a detailed contributors list:
-  ~  <https://gitlab.com/gateship-one/malp/blob/master/AUTHORS.md>
+  ~  <https://github.com/gateship-one/odyssey/blob/master/AUTHORS.md>
   ~
   ~  This program is free software: you can redistribute it and/or modify
   ~  it under the terms of the GNU General Public License as published by

--- a/app/src/main/res/anim/fragment_slide_in_bottom.xml
+++ b/app/src/main/res/anim/fragment_slide_in_bottom.xml
@@ -4,7 +4,7 @@
   ~  (Hendrik Borghorst & Frederik Luetkes)
   ~
   ~  The AUTHORS.md file contains a detailed contributors list:
-  ~  <https://gitlab.com/gateship-one/malp/blob/master/AUTHORS.md>
+  ~  <https://github.com/gateship-one/odyssey/blob/master/AUTHORS.md>
   ~
   ~  This program is free software: you can redistribute it and/or modify
   ~  it under the terms of the GNU General Public License as published by

--- a/app/src/main/res/anim/fragment_slide_out.xml
+++ b/app/src/main/res/anim/fragment_slide_out.xml
@@ -4,7 +4,7 @@
   ~  (Hendrik Borghorst & Frederik Luetkes)
   ~
   ~  The AUTHORS.md file contains a detailed contributors list:
-  ~  <https://gitlab.com/gateship-one/malp/blob/master/AUTHORS.md>
+  ~  <https://github.com/gateship-one/odyssey/blob/master/AUTHORS.md>
   ~
   ~  This program is free software: you can redistribute it and/or modify
   ~  it under the terms of the GNU General Public License as published by

--- a/app/src/main/res/anim/fragment_slide_out_bottom.xml
+++ b/app/src/main/res/anim/fragment_slide_out_bottom.xml
@@ -4,7 +4,7 @@
   ~  (Hendrik Borghorst & Frederik Luetkes)
   ~
   ~  The AUTHORS.md file contains a detailed contributors list:
-  ~  <https://gitlab.com/gateship-one/malp/blob/master/AUTHORS.md>
+  ~  <https://github.com/gateship-one/odyssey/blob/master/AUTHORS.md>
   ~
   ~  This program is free software: you can redistribute it and/or modify
   ~  it under the terms of the GNU General Public License as published by

--- a/app/src/main/res/layout/gridview_item.xml
+++ b/app/src/main/res/layout/gridview_item.xml
@@ -3,7 +3,7 @@
   ~  (Hendrik Borghorst & Frederik Luetkes)
   ~
   ~  The AUTHORS.md file contains a detailed contributors list:
-  ~  <https://gitlab.com/gateship-one/malp/blob/master/AUTHORS.md>
+  ~  <https://github.com/gateship-one/odyssey/blob/master/AUTHORS.md>
   ~
   ~  This program is free software: you can redistribute it and/or modify
   ~  it under the terms of the GNU General Public License as published by
@@ -67,7 +67,7 @@
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
             android:layout_alignParentBottom="true"
-            android:background="?attr/malp_grid_gradient" />
+            android:background="?attr/odyssey_grid_gradient" />
 
         <TextView
             android:id="@+id/item_grid_text"

--- a/app/src/main/res/layout/listview_item.xml
+++ b/app/src/main/res/layout/listview_item.xml
@@ -4,7 +4,7 @@
   ~  (Hendrik Borghorst & Frederik Luetkes)
   ~
   ~  The AUTHORS.md file contains a detailed contributors list:
-  ~  <https://gitlab.com/gateship-one/malp/blob/master/AUTHORS.md>
+  ~  <https://github.com/gateship-one/odyssey/blob/master/AUTHORS.md>
   ~
   ~  This program is free software: you can redistribute it and/or modify
   ~  it under the terms of the GNU General Public License as published by

--- a/app/src/main/res/layout/listview_item_file.xml
+++ b/app/src/main/res/layout/listview_item_file.xml
@@ -3,7 +3,7 @@
   ~  (Hendrik Borghorst & Frederik Luetkes)
   ~
   ~  The AUTHORS.md file contains a detailed contributors list:
-  ~  <https://gitlab.com/gateship-one/malp/blob/master/AUTHORS.md>
+  ~  <https://github.com/gateship-one/odyssey/blob/master/AUTHORS.md>
   ~
   ~  This program is free software: you can redistribute it and/or modify
   ~  it under the terms of the GNU General Public License as published by

--- a/app/src/main/res/layout/listview_item_image.xml
+++ b/app/src/main/res/layout/listview_item_image.xml
@@ -3,7 +3,7 @@
   ~  (Hendrik Borghorst & Frederik Luetkes)
   ~
   ~  The AUTHORS.md file contains a detailed contributors list:
-  ~  <https://gitlab.com/gateship-one/malp/blob/master/AUTHORS.md>
+  ~  <https://github.com/gateship-one/odyssey/blob/master/AUTHORS.md>
   ~
   ~  This program is free software: you can redistribute it and/or modify
   ~  it under the terms of the GNU General Public License as published by

--- a/app/src/main/res/layout/listview_item_section.xml
+++ b/app/src/main/res/layout/listview_item_section.xml
@@ -3,7 +3,7 @@
   ~  (Hendrik Borghorst & Frederik Luetkes)
   ~
   ~  The AUTHORS.md file contains a detailed contributors list:
-  ~  <https://gitlab.com/gateship-one/malp/blob/master/AUTHORS.md>
+  ~  <https://github.com/gateship-one/odyssey/blob/master/AUTHORS.md>
   ~
   ~  This program is free software: you can redistribute it and/or modify
   ~  it under the terms of the GNU General Public License as published by

--- a/app/src/main/res/layout/view_preference_switch.xml
+++ b/app/src/main/res/layout/view_preference_switch.xml
@@ -4,7 +4,7 @@
   ~  (Hendrik Borghorst & Frederik Luetkes)
   ~
   ~  The AUTHORS.md file contains a detailed contributors list:
-  ~  <https://gitlab.com/gateship-one/malp/blob/master/AUTHORS.md>
+  ~  <https://github.com/gateship-one/odyssey/blob/master/AUTHORS.md>
   ~
   ~  This program is free software: you can redistribute it and/or modify
   ~  it under the terms of the GNU General Public License as published by

--- a/app/src/main/res/mipmap-anydpi-v31/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v31/ic_launcher.xml
@@ -4,7 +4,7 @@
   ~  (Hendrik Borghorst & Frederik Luetkes)
   ~
   ~  The AUTHORS.md file contains a detailed contributors list:
-  ~  <https://gitlab.com/gateship-one/malp/blob/master/AUTHORS.md>
+  ~  <https://github.com/gateship-one/odyssey/blob/master/AUTHORS.md>
   ~
   ~  This program is free software: you can redistribute it and/or modify
   ~  it under the terms of the GNU General Public License as published by

--- a/app/src/main/res/values-v31/settings_values.xml
+++ b/app/src/main/res/values-v31/settings_values.xml
@@ -3,7 +3,7 @@
   ~  (Hendrik Borghorst & Frederik Luetkes)
   ~
   ~  The AUTHORS.md file contains a detailed contributors list:
-  ~  <https://gitlab.com/gateship-one/malp/blob/master/AUTHORS.md>
+  ~  <https://github.com/gateship-one/odyssey/blob/master/AUTHORS.md>
   ~
   ~  This program is free software: you can redistribute it and/or modify
   ~  it under the terms of the GNU General Public License as published by

--- a/app/src/main/res/values-v31/styles.xml
+++ b/app/src/main/res/values-v31/styles.xml
@@ -3,7 +3,7 @@
   ~  (Hendrik Borghorst & Frederik Luetkes)
   ~
   ~  The AUTHORS.md file contains a detailed contributors list:
-  ~  <https://gitlab.com/gateship-one/malp/blob/master/AUTHORS.md>
+  ~  <https://github.com/gateship-one/odyssey/blob/master/AUTHORS.md>
   ~
   ~  This program is free software: you can redistribute it and/or modify
   ~  it under the terms of the GNU General Public License as published by

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -22,7 +22,7 @@
 
 <resources>
     <declare-styleable name="OdysseyColors">
-        <attr name="malp_grid_gradient" format="reference" />u
+        <attr name="odyssey_grid_gradient" format="reference" />u
 
         <!-- Color used for surface structures like NPV view (e.g. original orange). Mostly used for legacy themes -->
         <attr name="app_color_surface" format="reference|color" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -3,7 +3,7 @@
   ~  (Hendrik Borghorst & Frederik Luetkes)
   ~
   ~  The AUTHORS.md file contains a detailed contributors list:
-  ~  <https://gitlab.com/gateship-one/malp/blob/master/AUTHORS.md>
+  ~  <https://github.com/gateship-one/odyssey/blob/master/AUTHORS.md>
   ~
   ~  This program is free software: you can redistribute it and/or modify
   ~  it under the terms of the GNU General Public License as published by
@@ -26,7 +26,7 @@
         <item name="windowActionBar">false</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="windowNoTitle">true</item>
-        <item name="malp_grid_gradient">@drawable/gradient_gridview_item_dark</item>
+        <item name="odyssey_grid_gradient">@drawable/gradient_gridview_item_dark</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="app_color_surface">?attr/colorSurface</item>
         <item name="app_color_on_surface">?attr/colorOnSurface</item>
@@ -55,7 +55,7 @@
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="windowNoTitle">true</item>
         <item name="android:windowLightStatusBar" tools:targetApi="m">true</item>
-        <item name="malp_grid_gradient">@drawable/gradient_gridview_item_dark</item>
+        <item name="odyssey_grid_gradient">@drawable/gradient_gridview_item_dark</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="app_color_surface">?attr/colorSurface</item>
         <item name="app_color_on_surface">?attr/colorOnSurface</item>
@@ -83,7 +83,7 @@
         <item name="windowActionBar">false</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="windowNoTitle">true</item>
-        <item name="malp_grid_gradient">@drawable/gradient_gridview_item_dark</item>
+        <item name="odyssey_grid_gradient">@drawable/gradient_gridview_item_dark</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar" tools:targetApi="m">?attr/isLightTheme</item>
         <item name="app_color_surface">?attr/colorSurface</item>
@@ -269,7 +269,7 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
-        <!-- malp color values -->
+        <!-- odyssey color values -->
         <item name="colorPrimaryDark">?attr/app_color_surface_darker</item>
         <item name="colorPrimary">?attr/app_color_surface</item>
         <item name="colorOnPrimary">?attr/app_color_on_surface</item>
@@ -278,7 +278,7 @@
         <item name="colorSecondary">?attr/app_color_secondary</item>
         <item name="colorOnSecondary">?attr/app_color_secondary</item>
         <item name="app_color_cover_background">#111111</item>
-        <item name="malp_grid_gradient">@drawable/gradient_gridview_item_dark</item>
+        <item name="odyssey_grid_gradient">@drawable/gradient_gridview_item_dark</item>
         <item name="app_color_on_surface_highlight">?attr/app_color_secondary</item>
         <item name="app_color_on_content">#ffffff</item>
         <item name="app_color_fanart_activity_tint">#ffffff</item>
@@ -293,7 +293,7 @@
         <item name="windowNoTitle">true</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
-        <!-- malp color values -->
+        <!-- odyssey color values -->
         <item name="colorPrimaryDark">?attr/app_color_surface_darker</item>
         <item name="colorAccent">?attr/app_color_secondary</item>
         <item name="colorPrimary">?attr/app_color_surface</item>
@@ -304,7 +304,7 @@
         <item name="colorPrimaryContainer">?attr/app_color_secondary</item>
         <item name="colorOnPrimaryContainer">?attr/app_color_on_secondary</item>
         <item name="app_color_cover_background">#FFFFFF</item>
-        <item name="malp_grid_gradient">@drawable/gradient_gridview_item_light</item>
+        <item name="odyssey_grid_gradient">@drawable/gradient_gridview_item_light</item>
         <item name="app_color_on_surface_highlight">?attr/app_color_secondary</item>
         <item name="app_color_on_content">@android:color/black</item>
         <item name="app_color_fanart_activity_tint">#ffffff</item>
@@ -341,7 +341,7 @@
         <item name="windowActionBar">false</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="windowNoTitle">true</item>
-        <item name="malp_grid_gradient">@drawable/gradient_gridview_item_dark</item>
+        <item name="odyssey_grid_gradient">@drawable/gradient_gridview_item_dark</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="app_color_surface">?attr/colorSurface</item>
         <item name="app_color_on_surface">?attr/colorOnSurface</item>
@@ -364,7 +364,7 @@
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="windowNoTitle">true</item>
         <item name="android:windowLightStatusBar" tools:targetApi="m">true</item>
-        <item name="malp_grid_gradient">@drawable/gradient_gridview_item_dark</item>
+        <item name="odyssey_grid_gradient">@drawable/gradient_gridview_item_dark</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="app_color_surface">?attr/colorSurface</item>
         <item name="app_color_on_surface">?attr/colorOnSurface</item>


### PR DESCRIPTION
Fixing what appears to be copy and paste errors; that reference the [M.A.L.P.](https://gitlab.com/gateship-one/malp) project.

Note: I did not update the [AUTHORS.md](https://github.com/gateship-one/odyssey/blob/master/AUTHORS.md). Assuming the authors of the copied work are already listed there.