### PR TITLE
Issue #192 (Track Sort) Workaround

### DIFF
--- a/app/src/main/java/org/gateshipone/odyssey/utils/MusicLibraryHelper.java
+++ b/app/src/main/java/org/gateshipone/odyssey/utils/MusicLibraryHelper.java
@@ -192,7 +192,12 @@ public class MusicLibraryHelper {
         String orderBy;
 
         if (orderKey.equals(context.getString(R.string.pref_album_tracks_sort_number_key))) {
-            orderBy = ProjectionTracks.TRACK;
+            if (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q) {
+                orderBy = "CAST(" + ProjectionTracks.TRACK + " AS unsigned)";
+            }
+            else{
+                orderBy = ProjectionTracks.TRACK;
+            }
         } else if (orderKey.equals(context.getString(R.string.pref_album_tracks_sort_name_key))) {
             orderBy = ProjectionTracks.DISPLAY_NAME;
         } else {


### PR DESCRIPTION
# Workaround for Issue #192 

The query of MediaStore.Audio.Media.TRACK is in some low versions with API-Level 29 (Android Q) a string (Should be an int).
Therefore the normal "oderBy" does not Work as desired.

Reference
[Stackoverflow: Problem sorting Mediastore track number containing String values](https://stackoverflow.com/questions/65480560/problem-sorting-mediastore-track-number-containing-string-values)


