### PR TITLE
"Play next" for artists and albums

### DIFF
--- a/app/src/main/aidl/org/gateshipone/odyssey/playbackservice/IOdysseyPlaybackService.aidl
+++ b/app/src/main/aidl/org/gateshipone/odyssey/playbackservice/IOdysseyPlaybackService.aidl
@@ -47,14 +47,14 @@ interface IOdysseyPlaybackService {
     void playPlaylist(in PlaylistModel playlist, int position);
 
     // enqueue all tracks of an album from mediastore
-    void enqueueAlbum(long albumId, String orderKey);
+    void enqueueAlbum(long albumId, String orderKey, boolean asNext);
     void playAlbum(long albumId, String orderKey, int position);
 
     void enqueueRecentAlbums();
     void playRecentAlbums();
 
     // enqueue all tracks of an artist from mediastore
-    void enqueueArtist(long artistId, String albumOrderKey, String trackOrderKey);
+    void enqueueArtist(long artistId, String albumOrderKey, String trackOrderKey, boolean asNext);
     void playArtist(long artistId, String albumOrderKey, String trackOrderKey);
 
     /**

--- a/app/src/main/java/org/gateshipone/odyssey/fragments/AlbumTracksFragment.java
+++ b/app/src/main/java/org/gateshipone/odyssey/fragments/AlbumTracksFragment.java
@@ -404,7 +404,7 @@ public class AlbumTracksFragment extends OdysseyRecyclerFragment<TrackModel, Gen
         String trackOrderKey = sharedPref.getString(getString(R.string.pref_album_tracks_sort_order_key), getString(R.string.pref_album_tracks_sort_default));
 
         try {
-            ((GenericActivity) requireActivity()).getPlaybackService().enqueueAlbum(mAlbum.getAlbumId(), trackOrderKey);
+            ((GenericActivity) requireActivity()).getPlaybackService().enqueueAlbum(mAlbum.getAlbumId(), trackOrderKey, false);
         } catch (RemoteException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();

--- a/app/src/main/java/org/gateshipone/odyssey/fragments/AlbumsFragment.java
+++ b/app/src/main/java/org/gateshipone/odyssey/fragments/AlbumsFragment.java
@@ -131,7 +131,10 @@ public class AlbumsFragment extends GenericAlbumsFragment {
         final int itemId = item.getItemId();
 
         if (itemId == R.id.fragment_albums_action_enqueue) {
-            enqueueAlbum(info.position);
+            enqueueAlbum(info.position, false);
+            return true;
+        } else if (itemId == R.id.fragment_albums_action_enqueueasnext) {
+            enqueueAlbum(info.position, true);
             return true;
         } else if (itemId == R.id.fragment_albums_action_play) {
             playAlbum(info.position);

--- a/app/src/main/java/org/gateshipone/odyssey/fragments/ArtistAlbumsFragment.java
+++ b/app/src/main/java/org/gateshipone/odyssey/fragments/ArtistAlbumsFragment.java
@@ -290,8 +290,9 @@ public class ArtistAlbumsFragment extends OdysseyRecyclerFragment<AlbumModel, Ge
      * Call the PBS to enqueue the selected album.
      *
      * @param position the position of the selected album in the adapter
+     * @param asNext
      */
-    protected void enqueueAlbum(int position) {
+    protected void enqueueAlbum(int position, boolean asNext) {
         // identify current album
         AlbumModel clickedAlbum = mRecyclerAdapter.getItem(position);
         long albumId = clickedAlbum.getAlbumId();
@@ -302,7 +303,7 @@ public class ArtistAlbumsFragment extends OdysseyRecyclerFragment<AlbumModel, Ge
 
         // enqueue album
         try {
-            ((GenericActivity) requireActivity()).getPlaybackService().enqueueAlbum(albumId, trackOrderKey);
+            ((GenericActivity) requireActivity()).getPlaybackService().enqueueAlbum(albumId, trackOrderKey, asNext);
         } catch (RemoteException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
@@ -359,11 +360,15 @@ public class ArtistAlbumsFragment extends OdysseyRecyclerFragment<AlbumModel, Ge
         }
 
         final int itemId = item.getItemId();
-
         if (itemId == R.id.fragment_artist_albums_action_enqueue) {
-            enqueueAlbum(info.position);
+            enqueueAlbum(info.position, false);
             return true;
-        } else if (itemId == R.id.fragment_artist_albums_action_play) {
+
+        } else if (itemId == R.id.fragment_artist_albums_action_enqueueasnext) {
+            enqueueAlbum(info.position, true);
+            return true;
+        }
+        else if (itemId == R.id.fragment_artist_albums_action_play) {
             playAlbum(info.position);
             return true;
         }
@@ -433,7 +438,7 @@ public class ArtistAlbumsFragment extends OdysseyRecyclerFragment<AlbumModel, Ge
 
         // enqueue artist
         try {
-            ((GenericActivity) requireActivity()).getPlaybackService().enqueueArtist(mArtist.getArtistID(), albumOrderKey, trackOrderKey);
+            ((GenericActivity) requireActivity()).getPlaybackService().enqueueArtist(mArtist.getArtistID(), albumOrderKey, trackOrderKey, false);
         } catch (RemoteException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();

--- a/app/src/main/java/org/gateshipone/odyssey/fragments/ArtistsFragment.java
+++ b/app/src/main/java/org/gateshipone/odyssey/fragments/ArtistsFragment.java
@@ -224,7 +224,10 @@ public class ArtistsFragment extends OdysseyFragment<ArtistModel> implements Ada
         final int itemId = item.getItemId();
 
         if (itemId == R.id.fragment_artist_action_enqueue) {
-            enqueueArtist(info.position);
+            enqueueArtist(info.position, false);
+            return true;
+        } else if (itemId == R.id.fragment_artist_action_enqueueasnext) {
+            enqueueArtist(info.position, true);
             return true;
         } else if (itemId == R.id.fragment_artist_action_play) {
             playArtist(info.position);
@@ -238,8 +241,9 @@ public class ArtistsFragment extends OdysseyFragment<ArtistModel> implements Ada
      * Call the PBS to enqueue the selected artist
      *
      * @param position the position of the selected artist in the adapter
+     * @param asNext
      */
-    private void enqueueArtist(int position) {
+    private void enqueueArtist(int position, boolean asNext) {
 
         // identify current artist
         ArtistModel currentArtist = mAdapter.getItem(position);
@@ -259,7 +263,7 @@ public class ArtistsFragment extends OdysseyFragment<ArtistModel> implements Ada
 
         // enqueue artist
         try {
-            ((GenericActivity) requireActivity()).getPlaybackService().enqueueArtist(artistId, albumOrderKey, trackOrderKey);
+            ((GenericActivity) requireActivity()).getPlaybackService().enqueueArtist(artistId, albumOrderKey, trackOrderKey, asNext);
         } catch (RemoteException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();

--- a/app/src/main/java/org/gateshipone/odyssey/fragments/GenericAlbumsFragment.java
+++ b/app/src/main/java/org/gateshipone/odyssey/fragments/GenericAlbumsFragment.java
@@ -174,8 +174,9 @@ public abstract class GenericAlbumsFragment extends OdysseyFragment<AlbumModel> 
      * Call the PBS to enqueue the selected album.
      *
      * @param position the position of the selected album in the adapter
+     * @param asNext
      */
-    protected void enqueueAlbum(int position) {
+    protected void enqueueAlbum(int position, boolean asNext) {
         // identify current album
         AlbumModel clickedAlbum = mAdapter.getItem(position);
         long albumId = clickedAlbum.getAlbumId();
@@ -186,7 +187,7 @@ public abstract class GenericAlbumsFragment extends OdysseyFragment<AlbumModel> 
 
         // enqueue album
         try {
-            ((GenericActivity) requireActivity()).getPlaybackService().enqueueAlbum(albumId, trackOrderKey);
+            ((GenericActivity) requireActivity()).getPlaybackService().enqueueAlbum(albumId, trackOrderKey, asNext);
         } catch (RemoteException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();

--- a/app/src/main/java/org/gateshipone/odyssey/fragments/RecentAlbumsFragment.java
+++ b/app/src/main/java/org/gateshipone/odyssey/fragments/RecentAlbumsFragment.java
@@ -144,9 +144,13 @@ public class RecentAlbumsFragment extends GenericAlbumsFragment {
         final int itemId = item.getItemId();
 
         if (itemId == R.id.fragment_albums_action_enqueue) {
-            enqueueAlbum(info.position);
+            enqueueAlbum(info.position, false);
             return true;
-        } else if (itemId == R.id.fragment_albums_action_play) {
+        } else if (itemId == R.id.fragment_albums_action_enqueueasnext) {
+            enqueueAlbum(info.position, true);
+            return true;
+        }
+        else if (itemId == R.id.fragment_albums_action_play) {
             playAlbum(info.position);
             return true;
         } else if (itemId == R.id.fragment_albums_action_showartist) {

--- a/app/src/main/java/org/gateshipone/odyssey/playbackservice/ControlObject.java
+++ b/app/src/main/java/org/gateshipone/odyssey/playbackservice/ControlObject.java
@@ -84,6 +84,13 @@ public class ControlObject {
         mAction = action;
     }
 
+    public ControlObject(PLAYBACK_ACTION action, long longParam, String param, boolean asNext) {
+        mLongParam = longParam;
+        mStringparam = param;
+        mBoolparam = asNext;
+        mAction = action;
+    }
+
     public ControlObject(PLAYBACK_ACTION action, long longParam, String param, int intParam) {
         mLongParam = longParam;
         mStringparam = param;
@@ -126,6 +133,14 @@ public class ControlObject {
         mLongParam = longParam;
         mStringparam = stringParam;
         mSecondStringParam = stringParam2;
+    }
+
+    public ControlObject(PLAYBACK_ACTION action, long longParam, String stringParam, String stringParam2, boolean boolParam) {
+        mAction = action;
+        mLongParam = longParam;
+        mStringparam = stringParam;
+        mSecondStringParam = stringParam2;
+        mBoolparam = boolParam;
     }
 
     public ControlObject(PLAYBACK_ACTION action, String stringParam, int intParam) {

--- a/app/src/main/java/org/gateshipone/odyssey/playbackservice/OdysseyPlaybackServiceInterface.java
+++ b/app/src/main/java/org/gateshipone/odyssey/playbackservice/OdysseyPlaybackServiceInterface.java
@@ -274,9 +274,10 @@ public class OdysseyPlaybackServiceInterface extends IOdysseyPlaybackService.Stu
         mService.get().getHandler().sendMessage(msg);
     }
 
+
     @Override
-    public void enqueueAlbum(long albumId, String orderKey) {
-        ControlObject obj = new ControlObject(ControlObject.PLAYBACK_ACTION.ODYSSEY_ENQUEUEALBUM, albumId, orderKey);
+    public void enqueueAlbum(long albumId, String orderKey, boolean asNext) {
+        ControlObject obj = new ControlObject(ControlObject .PLAYBACK_ACTION.ODYSSEY_ENQUEUEALBUM, albumId, orderKey, asNext);
         Message msg = mService.get().getHandler().obtainMessage();
         msg.obj = obj;
         mService.get().getHandler().sendMessage(msg);
@@ -307,8 +308,8 @@ public class OdysseyPlaybackServiceInterface extends IOdysseyPlaybackService.Stu
     }
 
     @Override
-    public void enqueueArtist(long artistId, String albumOrderKey, String trackOrderKey) {
-        ControlObject obj = new ControlObject(ControlObject.PLAYBACK_ACTION.ODYSSEY_ENQUEUEARTIST, artistId, albumOrderKey, trackOrderKey);
+    public void enqueueArtist(long artistId, String albumOrderKey, String trackOrderKey, boolean asNext) {
+        ControlObject obj = new ControlObject(ControlObject.PLAYBACK_ACTION.ODYSSEY_ENQUEUEARTIST, artistId, albumOrderKey, trackOrderKey, asNext);
         Message msg = mService.get().getHandler().obtainMessage();
         msg.obj = obj;
         mService.get().getHandler().sendMessage(msg);

--- a/app/src/main/java/org/gateshipone/odyssey/playbackservice/PlaybackServiceHandler.java
+++ b/app/src/main/java/org/gateshipone/odyssey/playbackservice/PlaybackServiceHandler.java
@@ -133,13 +133,13 @@ public class PlaybackServiceHandler extends Handler {
                     mService.get().playDirectoryAndSubDirectories(msgObj.getStringParam(), msgObj.getSecondStringParam());
                     break;
                 case ODYSSEY_ENQUEUEALBUM:
-                    mService.get().enqueueAlbum(msgObj.getLongParam(), msgObj.getStringParam());
+                    mService.get().enqueueAlbum(msgObj.getLongParam(), msgObj.getStringParam(), msgObj.getBoolParam());
                     break;
                 case ODYSSEY_PLAYALBUM:
                     mService.get().playAlbum(msgObj.getLongParam(), msgObj.getStringParam(), msgObj.getIntParam());
                     break;
                 case ODYSSEY_ENQUEUEARTIST:
-                    mService.get().enqueueArtist(msgObj.getLongParam(), msgObj.getStringParam(), msgObj.getSecondStringParam());
+                    mService.get().enqueueArtist(msgObj.getLongParam(), msgObj.getStringParam(), msgObj.getSecondStringParam(),msgObj.getBoolParam());
                     break;
                 case ODYSSEY_PLAYARTIST:
                     mService.get().playArtist(msgObj.getLongParam(), msgObj.getStringParam(), msgObj.getSecondStringParam());

--- a/app/src/main/res/menu/context_menu_albums_fragment.xml
+++ b/app/src/main/res/menu/context_menu_albums_fragment.xml
@@ -28,9 +28,17 @@
         app:showAsAction="never" />
 
     <item
+        android:id="@+id/fragment_albums_action_enqueueasnext"
+        android:title="@string/context_menu_action_enqueueasnext"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/fragment_albums_action_play"
         android:title="@string/context_menu_action_playalbum"
         app:showAsAction="never" />
+
+
+
 
     <item
         android:id="@+id/fragment_albums_action_showartist"

--- a/app/src/main/res/menu/context_menu_artist_albums_fragment.xml
+++ b/app/src/main/res/menu/context_menu_artist_albums_fragment.xml
@@ -28,6 +28,11 @@
         android:title="@string/context_menu_action_enqueue" />
 
     <item
+            android:id="@+id/fragment_artist_albums_action_enqueueasnext"
+            android:title="@string/context_menu_action_enqueueasnext"
+            app:showAsAction="never" />
+
+    <item
         android:id="@+id/fragment_artist_albums_action_play"
         app:showAsAction="never"
         android:title="@string/context_menu_action_playalbum" />

--- a/app/src/main/res/menu/context_menu_artists_fragment.xml
+++ b/app/src/main/res/menu/context_menu_artists_fragment.xml
@@ -26,7 +26,10 @@
         android:id="@+id/fragment_artist_action_enqueue"
         app:showAsAction="never"
         android:title="@string/context_menu_action_enqueue" />
-
+    <item
+        android:id="@+id/fragment_artist_action_enqueueasnext"
+        android:title="@string/context_menu_action_enqueueasnext"
+        app:showAsAction="never" />
     <item
         android:id="@+id/fragment_artist_action_play"
         app:showAsAction="never"


### PR DESCRIPTION
Hi, thanks for the great App!

The "Play Next" function currently only works for individual tracks.
I was used to having this feature for whole albums and artist as well, so I implemented it in my fork.
I tested it on my personal device and with an emulator - it seems to work fine.

I think the "most interesting" part of the code (meaning the one most likely to have bugs), is the new method: `PlaybackService.enqueueAsNextTracks`.

The implementation borrows from both the `enqueueTrackAsNext` and the `enqueueTracks` methods.
Songs are added after the current playing song, but if no song is currently playing, the newly enqueued album *won't* start playing (like it would when enqueuing tracks via `enqueueTrackAsNext`).

Are you interested in integrating this into odyssey?
If not, feel free to close this PR :) 